### PR TITLE
Add/async support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Span: A Web Worker Bridging Module
+
 [![deno module](https://shield.deno.dev/x/span)](https://deno.land/x/span)
 [![Unit Test CI](https://github.com/joshLong145/Span/actions/workflows/test.yml/badge.svg)](https://github.com/joshLong145/Span/actions/workflows/test.yml)
 
@@ -104,20 +105,20 @@ class Example extends WorkerDefinition {
     super();
   }
 
-  public addOne(
+  addOne = (
     buffer: SharedArrayBuffer,
     args: Record<string, any>,
-  ): SharedArrayBuffer {
+  ): SharedArrayBuffer => {
     console.log("param name value: ", args.name);
     const arr = new Int8Array(buffer);
     arr[0] += 1;
     return buffer;
   }
 
-  public fib(
+  fib = (
     buffer: SharedArrayBuffer,
     module: Record<string, any>,
-  ): SharedArrayBuffer {
+  ): SharedArrayBuffer => {
     let i;
     const arr = new Uint8Array(buffer);
     arr[0] = 0;
@@ -178,7 +179,7 @@ class Example extends WasmWorkerDefinition {
         super(modulePath);
     }
 
-    public test(buffer: SharedArrayBuffer, module: any) {
+    addOne = (buffer: SharedArrayBuffer, module: any) => {
         let arr = new Int8Array(buffer);
         arr[0] += 1
         //@ts-ignore
@@ -204,7 +205,7 @@ const wrapper: WasmInstanceWrapper<Example> = new WasmInstanceWrapper<Example>(e
 
 wrapper.start();
 //@ts-ignore
-await example.execute("test").then((buf: SharedArrayBuffer) => {
+await example.execute("addOne").then((buf: SharedArrayBuffer) => {
     console.log("buffer returned ", new Int32Array(buf))
 });
 

--- a/README.md
+++ b/README.md
@@ -45,20 +45,20 @@ class Example extends WorkerDefinition {
     super();
   }
 
-  public addOne(
+  addOne = (
     buffer: SharedArrayBuffer,
     args: Record<string, any>,
-  ): SharedArrayBuffer {
+  ): SharedArrayBuffer => {
     console.log("param name value: ", args.name);
     const arr = new Int8Array(buffer);
     arr[0] += 1;
     return buffer;
   }
 
-  public fib(
+  fib = (
     buffer: SharedArrayBuffer,
     module: Record<string, any>,
-  ): SharedArrayBuffer {
+  ): SharedArrayBuffer => {
     let i;
     const arr = new Uint8Array(buffer);
     arr[0] = 0;

--- a/benchmark/wasm_instance_start_bench.ts
+++ b/benchmark/wasm_instance_start_bench.ts
@@ -1,8 +1,5 @@
 //@ts-nocheck
-import {
-  assertEquals,
-  assertExists,
-} from "https://deno.land/std@0.210.0/assert/mod.ts";
+
 import {
   WasmInstanceWrapper,
   WasmWorkerDefinition,
@@ -13,16 +10,19 @@ class TestExample extends WasmWorkerDefinition {
     super(modulePath);
   }
 
-  public test2(buffer: SharedArrayBuffer, module: Record<string, any>) {
-    let arr = new Int8Array(buffer);
+  test2 = (
+    buffer: SharedArrayBuffer,
+    _module: Record<string, any>,
+  ): SharedArrayBuffer => {
+    const arr = new Int8Array(buffer);
     arr[0] += 1;
 
     self.primeGenerator();
     return arr.buffer;
-  }
+  };
 }
 
-Deno.bench("Wasm Worker Start Go Module loading", async (b) => {
+Deno.bench("Wasm Worker Start Go Module loading", async (_b) => {
   const example: WasmWorkerDefinition = new TestExample(
     "./examples/wasm/tiny-go/primes-2.wasm",
   );
@@ -33,7 +33,7 @@ Deno.bench("Wasm Worker Start Go Module loading", async (b) => {
     example,
     {
       outputPath: "output",
-      namespace: "asd",
+      namespace: "testing",
       addons: [
         "./lib/wasm_exec_tiny.js",
       ],
@@ -42,18 +42,19 @@ Deno.bench("Wasm Worker Start Go Module loading", async (b) => {
       },
       moduleLoader: (path: string) => {
         const fd = Deno.openSync(path);
-        let mod = Deno.readAllSync(fd);
+        const mod = Deno.readFileSync(fd);
         fd.close();
         return mod;
       },
     },
   );
+
   await wrapper.start().then(() => {
     example.terminateWorker();
   });
 });
 
-Deno.bench("Wasm Worker Start Rust Module loading", async (b) => {
+Deno.bench("Wasm Worker Start Rust Module loading", async (_b) => {
   const example: WasmWorkerDefinition = new TestExample(
     "./examples/wasm/rust/wasm_test_bg.wasm",
   );
@@ -73,12 +74,13 @@ Deno.bench("Wasm Worker Start Rust Module loading", async (b) => {
       },
       moduleLoader: (path: string) => {
         const fd = Deno.openSync(path);
-        let mod = Deno.readAllSync(fd);
+        const mod = Deno.readAllSync(fd);
         fd.close();
         return mod;
       },
     },
   );
+
   await wrapper.start().then(() => {
     example.terminateWorker();
   });

--- a/examples/js/example.ts
+++ b/examples/js/example.ts
@@ -1,26 +1,29 @@
 import { InstanceConfiguration } from "../../src/types.ts";
 import { InstanceWrapper, WorkerDefinition } from "./../../src/mod.ts";
+import { sleep } from "https://deno.land/x/sleep/mod.ts";
+
 class Example extends WorkerDefinition {
   public constructor() {
     super();
   }
 
-  public addOne(
+  addOne = async (
     buffer: SharedArrayBuffer,
     args: Record<string, any>,
-  ): SharedArrayBuffer {
+  ): Promise<SharedArrayBuffer> => {
     console.log("param name value: ", args.name);
-    const arr = new Int8Array(buffer);
+    const arr = new Uint32Array(buffer);
     arr[0] += 1;
-    return buffer;
-  }
 
-  public fib(
+    return buffer;
+  };
+
+  fib = async (
     buffer: SharedArrayBuffer,
     args: Record<string, any>,
-  ): SharedArrayBuffer {
+  ): Promise<SharedArrayBuffer> => {
     let i;
-    const arr = new Uint8Array(buffer);
+    const arr = new Uint32Array(buffer);
     arr[0] = 0;
     arr[1] = 1;
 
@@ -28,9 +31,25 @@ class Example extends WorkerDefinition {
       arr[i] = arr[i - 2] + arr[i - 1];
       console.log(arr[i]);
     }
+    let adapter;
+    await navigator.gpu.requestAdapter().then((adpt) => {
+      adapter = adpt;
+      console.log(adapter);
+    });
+
+    let keyPair = await crypto.subtle.generateKey(
+      {
+        name: "RSA-OAEP",
+        modulusLength: 4096,
+        publicExponent: new Uint8Array([1, 0, 1]),
+        hash: "SHA-256",
+      },
+      true,
+      ["encrypt", "decrypt"],
+    );
 
     return buffer;
-  }
+  };
 }
 
 const example: Example = new Example();
@@ -41,6 +60,10 @@ const wrapper: InstanceWrapper<Example> = new InstanceWrapper<Example>(
 );
 
 wrapper.start();
+
+(example as any).worker.onerror = (event: any) => {
+  console.log("an error occured ", event);
+};
 
 await example.execute("addOne", { name: "foo" }).then(
   (buf: SharedArrayBuffer) => {
@@ -53,10 +76,10 @@ await example.execute("addOne", { name: "foo" }).then(
   },
 );
 
-await example.execute("fib", { count: 10 }).then(
+await example.execute("fib", { count: 46 }).then(
   (buffer: SharedArrayBuffer) => {
-    console.log("fib result ", new Uint8Array(buffer));
-    console.log("last fib number", new Uint8Array(buffer)[10]);
+    console.log("fib result ", new Uint32Array(buffer));
+    console.log("last fib number", new Uint32Array(buffer)[46]);
   },
 );
 

--- a/examples/wasm/rust/example.ts
+++ b/examples/wasm/rust/example.ts
@@ -8,13 +8,13 @@ class Example extends WasmWorkerDefinition {
     super(modulePath);
   }
 
-  public test2(buffer: SharedArrayBuffer, args: Record<string, any>) {
+  test2 = (buffer: SharedArrayBuffer, args: Record<string, any>) => {
     let arr = new Int8Array(buffer);
     arr[0] += 1;
     //@ts-ignore
     self.greet();
     return arr.buffer;
-  }
+  };
 }
 
 const example: Example = new Example(

--- a/src/InstanceWrapper.ts
+++ b/src/InstanceWrapper.ts
@@ -117,12 +117,14 @@ export class InstanceWrapper<T extends WorkerDefinition> {
   }
 
   private _generate(): void {
-    const keys = Reflect.ownKeys(
+    const protoKeys = Reflect.ownKeys(
       Object.getPrototypeOf(this._instance),
     ) as [keyof T];
+    const baseKeys = Object.keys(this._instance) as [keyof T];
+
     const wrps: WorkerWrapper[] = [];
-    for (const key of keys) {
-      key !== "constructor" &&
+    for (const key of protoKeys.concat(baseKeys)) {
+      key !== "constructor" && key !== "execMap" && key !== "worker" &&
         wrps.push(new WorkerWrapper(this._instance[key] as WorkerMethod));
     }
 

--- a/src/InstanceWrapper.ts
+++ b/src/InstanceWrapper.ts
@@ -41,7 +41,8 @@ export class WorkerDefinition {
   /**
    * worker instance, can be stopped by calling terminateWorker
    */
-  public worker: Worker | undefined = undefined;
+  // deno-lint-ignore no-explicit-any
+  public worker: any | undefined = undefined;
 
   constructor() {}
 

--- a/src/WasmInstanceWrapper.ts
+++ b/src/WasmInstanceWrapper.ts
@@ -81,14 +81,18 @@ export class WasmInstanceWrapper<T extends WasmWorkerDefinition> {
   }
 
   private _generate(): void {
-    const keys = Reflect.ownKeys(Object.getPrototypeOf(this._instance)) as [
-      keyof T,
-    ];
+    const protoKeys = Reflect.ownKeys(
+      Object.getPrototypeOf(this._instance),
+    ) as [keyof T];
+    const baseKeys = Object.keys(this._instance) as [keyof T];
+
     const wrps: WorkerWrapper[] = [];
-    for (const key of keys) {
-      key !== "constructor" &&
+    for (const key of protoKeys.concat(baseKeys)) {
+      key !== "constructor" && key !== "execMap" && key !== "worker" &&
+        key !== "ModulePath" && key !== "workerString" &&
         wrps.push(new WorkerWrapper(this._instance[key] as WorkerMethod));
     }
+
     this._wm = new WorkerManager(wrps);
     this._wb = new WorkerBridge({
       workers: wrps,

--- a/src/WasmInstanceWrapper.ts
+++ b/src/WasmInstanceWrapper.ts
@@ -24,7 +24,8 @@ export class WasmWorkerDefinition {
   /**
    * Worker instance, can be stopped by calling terminateWorker
    */
-  public worker: Worker | undefined = undefined;
+  // deno-lint-ignore no-explicit-any
+  public worker: any | undefined = undefined;
 
   /**
    * Path to the WASM module being loaded into the worker.
@@ -203,7 +204,7 @@ export class WasmInstanceWrapper<T extends WasmWorkerDefinition> {
     }
     const enc = new TextEncoder();
     this._generate();
-    let worker = `
+    const worker = `
 ${this.workerString}\n
 ${this?._wm?.CreateWorkerMap()}\n
 ${this?._wm?.CreateOnMessageHandler()}`;

--- a/src/WorkerBridge.ts
+++ b/src/WorkerBridge.ts
@@ -32,8 +32,8 @@ export class WorkerBridge<T> {
 
     for (const worker of this._workers) {
       root += `
-            // this buffer size should be a config option, 
-            _bufferMap["${worker.WorkerName}"] = typeof SharedArrayBuffer != "undefined" ? new SharedArrayBuffer(1024) : new Uint8Array();\n
+// this buffer size should be a config option, 
+_bufferMap["${worker.WorkerName}"] = typeof SharedArrayBuffer != "undefined" ? new SharedArrayBuffer(1024) : new Uint8Array();\n
             `;
     }
 
@@ -70,7 +70,7 @@ export class WorkerBridge<T> {
       prmsRes = res;
     });
 
-    self.worker = new Worker(objUrl, { deno: true, type: "module" });
+    self.worker = this._genWebWorker(objUrl);
     self.worker.onmessage = (e: MessageEvent<any>) => {
       if (e.data.ready) {
         prmsRes();
@@ -193,6 +193,12 @@ for (const key of Object.keys(${this._namespace})) {
 self['worker'] = worker;
 `;
     return root;
+  }
+
+  private _genWebWorker(objUrl: URL): any {
+    const worker = new Worker(objUrl, { deno: true, type: "module" });
+
+    return worker;
   }
 
   public createBridge(worker: string): string {

--- a/src/WorkerManager.ts
+++ b/src/WorkerManager.ts
@@ -18,19 +18,23 @@ export class WorkerManager {
 
   public CreateOnMessageHandler(): string {
     return `const execData = [];
-            self.setInterval(() => {
+            self.setInterval(async () => {
             if (execData.length > 0 && workerState === "READY") {
                   const task = execData.shift();
                   let res = _execMap[task.name](task.buffer, task.args);
+                  if (res.then) {
+                    res = await res;
+                  }
+
                   postMessage({
                       name: task.name,
                       buffer: task.buffer,
                       id: task.id,
-                      res,
                       state: workerState,
+                      res
                   });
             }
-          }, 10);
+          }, 100);
 
           self.onmessage = (e) => {
             execData.push(e.data);

--- a/src/WorkerManager.ts
+++ b/src/WorkerManager.ts
@@ -20,6 +20,7 @@ export class WorkerManager {
     return `const execData = [];
             self.setInterval(async () => {
             if (execData.length > 0 && workerState === "READY") {
+                try {
                   const task = execData.shift();
                   let res = _execMap[task.name](task.buffer, task.args);
                   if (res.then) {
@@ -33,8 +34,11 @@ export class WorkerManager {
                       state: workerState,
                       res
                   });
+                } catch(e) {
+                  console.error('Error while executing task. Error trace:' + e.message);
+                }
             }
-          }, 100);
+          }, 1);
 
           self.onmessage = (e) => {
             execData.push(e.data);

--- a/src/WorkerWrapper.ts
+++ b/src/WorkerWrapper.ts
@@ -15,7 +15,7 @@ export class WorkerWrapper {
   }
 
   private _serializeWorker(): string {
-    return `function ${this._worker.toString()}`;
+    return `${this._worker.toString()}`;
   }
 
   public CreateExecMapping(): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,7 +67,14 @@ export type WorkerInstance<T extends WorkerDefinition> = WorkerFunctions<
   T
 >;
 
-export declare type WorkerMethod = (
+export declare type WorkerMethod = SyncWorkerMethod | AsyncWorkerMethod;
+
+export declare type AsyncWorkerMethod = (
+  buffer: SharedArrayBuffer,
+  module: Record<string, any>,
+) => Promise<ArrayBuffer>;
+
+export declare type SyncWorkerMethod = (
   buffer: SharedArrayBuffer,
   module: Record<string, any>,
 ) => ArrayBuffer;

--- a/tests/instance_wrapper_runtime_test.ts
+++ b/tests/instance_wrapper_runtime_test.ts
@@ -11,7 +11,7 @@ class TestExample extends WorkerDefinition {
 
   foo = (
     buffer: SharedArrayBuffer,
-    module: Record<string, any>,
+    _args: Record<string, any>,
   ): ArrayBuffer => {
     const arr = new Int8Array(buffer);
     arr[0] += 1;
@@ -23,7 +23,21 @@ class TestExample extends WorkerDefinition {
     buffer: SharedArrayBuffer,
     args: Record<string, any>,
   ): SharedArrayBuffer => {
-    const arr = new Uint8Array(buffer)[0] = args.value;
+    const _arr = new Uint8Array(buffer)[0] = args.value;
+
+    return buffer;
+  };
+
+  testAsync = async (
+    buffer: SharedArrayBuffer,
+    _args: Record<string, any>,
+  ): Promise<SharedArrayBuffer> => {
+    const prms: Promise<void> = new Promise((res, _rej) => {
+      const a = 2 + 2;
+      console.log("a value is ", a);
+      res();
+    });
+    await prms;
     return buffer;
   };
 }
@@ -41,6 +55,8 @@ Deno.test("Worker Wrapper manager should respect buffer when returned", async ()
   await inst.execute("foo").then((buf) => {
     assertEquals(new Uint32Array(buf)[0], 2);
   });
+
+  await inst.execute("testAsync");
 
   inst.terminateWorker();
 });

--- a/tests/instance_wrapper_runtime_test.ts
+++ b/tests/instance_wrapper_runtime_test.ts
@@ -9,23 +9,23 @@ class TestExample extends WorkerDefinition {
     super();
   }
 
-  public foo(
+  foo = (
     buffer: SharedArrayBuffer,
     module: Record<string, any>,
-  ): ArrayBuffer {
+  ): ArrayBuffer => {
     const arr = new Int8Array(buffer);
     arr[0] += 1;
 
     return buffer;
-  }
+  };
 
-  public bar(
+  bar = (
     buffer: SharedArrayBuffer,
     args: Record<string, any>,
-  ): SharedArrayBuffer {
+  ): SharedArrayBuffer => {
     const arr = new Uint8Array(buffer)[0] = args.value;
     return buffer;
-  }
+  };
 }
 
 Deno.test("Worker Wrapper manager should respect buffer when returned", async () => {

--- a/tests/instance_wrapper_standup_test.ts
+++ b/tests/instance_wrapper_standup_test.ts
@@ -9,14 +9,14 @@ class TestExample extends WorkerDefinition {
     super();
   }
 
-  public foo(
+  foo = (
     buffer: SharedArrayBuffer,
     module: Record<string, any>,
-  ): SharedArrayBuffer {
+  ): SharedArrayBuffer => {
     let arr = new Uint8Array(buffer);
     arr[0] += 1;
     return buffer;
-  }
+  };
 }
 
 Deno.test("Worker Wrapper should be defined", () => {

--- a/tests/instance_wrapper_static_generation_test.ts
+++ b/tests/instance_wrapper_static_generation_test.ts
@@ -11,23 +11,23 @@ class TestExample extends WorkerDefinition {
     super();
   }
 
-  public foo(
+  foo = (
     buffer: SharedArrayBuffer,
     module: Record<string, any>,
-  ): ArrayBuffer {
+  ): ArrayBuffer => {
     const arr = new Int8Array(buffer);
     arr[0] += 1;
     console.log("this is foo", module);
     return buffer;
-  }
+  };
 
-  public bar(
+  bar = (
     buffer: SharedArrayBuffer,
     args: Record<string, any>,
-  ): SharedArrayBuffer {
+  ): SharedArrayBuffer => {
     const arr = new Uint8Array(buffer)[0] = args.value;
     return buffer;
-  }
+  };
 }
 
 Deno.test("Generated bridge should load functions into global", async () => {

--- a/tests/instance_wrapper_static_generation_test.ts
+++ b/tests/instance_wrapper_static_generation_test.ts
@@ -6,6 +6,12 @@ import { InstanceWrapper, WorkerDefinition } from "../src/mod.ts";
 import { existsSync } from "https://deno.land/std/fs/mod.ts";
 import * as path from "https://deno.land/std@0.188.0/path/mod.ts";
 
+declare global {
+  var foo: (args: Record<string, any>) => void;
+  var bar: (args: Record<string, any>) => void;
+  var worker: Worker;
+}
+
 class TestExample extends WorkerDefinition {
   public constructor() {
     super();
@@ -45,9 +51,9 @@ Deno.test("Generated bridge should load functions into global", async () => {
   });
   const __dirname = path.dirname(path.fromFileUrl(import.meta.url));
   await import(__dirname + "/../public/bridge.js");
-  //@ts-ignore
+
   assertExists(self["bar"]);
-  //@ts-ignore
+
   assertExists(self["bar"]);
   await self["foo"]({ hey: "wow" });
 

--- a/tests/wasm_instance_wrapper_runtime_test.ts
+++ b/tests/wasm_instance_wrapper_runtime_test.ts
@@ -11,33 +11,33 @@ class GoTestExample extends WasmWorkerDefinition {
     super(modulePath);
   }
 
-  public testBuffer(
+  testBuffer = (
     buffer: SharedArrayBuffer,
     args: Record<string, any>,
-  ): SharedArrayBuffer {
+  ): SharedArrayBuffer => {
     let arr = new Int8Array(buffer);
     arr[0] += 1;
     //@ts-ignore wasm
     self.primeGenerator();
 
     return buffer;
-  }
+  };
 
-  public testParams(
+  testParams = (
     buffer: SharedArrayBuffer,
     args: Record<string, any>,
-  ): SharedArrayBuffer {
+  ): SharedArrayBuffer => {
     let arr = new Int32Array(buffer);
     arr[0] = args.foo;
     return buffer;
-  }
+  };
 }
 class RustTestExample extends WasmWorkerDefinition {
   public constructor(modulePath: string) {
     super(modulePath);
   }
 
-  public test2(buffer: SharedArrayBuffer, args: Record<string, any>) {
+  test2 = (buffer: SharedArrayBuffer, args: Record<string, any>) => {
     console.log(args.dom);
     let arr = new Int8Array(buffer);
     arr[0] += 1;
@@ -47,7 +47,7 @@ class RustTestExample extends WasmWorkerDefinition {
     let val = self.getValue();
     console.log(val);
     return arr.buffer;
-  }
+  };
 }
 
 Deno.test("WASM Worker Should have wasm methods loaded from module", async () => {

--- a/tests/wasm_instance_wrapper_runtime_test.ts
+++ b/tests/wasm_instance_wrapper_runtime_test.ts
@@ -13,11 +13,11 @@ class GoTestExample extends WasmWorkerDefinition {
 
   testBuffer = (
     buffer: SharedArrayBuffer,
-    args: Record<string, any>,
+    _args: Record<string, any>,
   ): SharedArrayBuffer => {
-    let arr = new Int8Array(buffer);
+    const arr = new Int8Array(buffer);
     arr[0] += 1;
-    //@ts-ignore wasm
+    //@ts-ignore wasm module function
     self.primeGenerator();
 
     return buffer;
@@ -27,8 +27,21 @@ class GoTestExample extends WasmWorkerDefinition {
     buffer: SharedArrayBuffer,
     args: Record<string, any>,
   ): SharedArrayBuffer => {
-    let arr = new Int32Array(buffer);
+    const arr = new Int32Array(buffer);
     arr[0] = args.foo;
+    return buffer;
+  };
+
+  testAsync = async (
+    buffer: SharedArrayBuffer,
+    _args: Record<string, any>,
+  ): Promise<SharedArrayBuffer> => {
+    const prms: Promise<void> = new Promise((res, _rej) => {
+      const a = 2 + 2;
+      console.log("a value is ", a);
+      res();
+    });
+    await prms;
     return buffer;
   };
 }
@@ -39,18 +52,18 @@ class RustTestExample extends WasmWorkerDefinition {
 
   test2 = (buffer: SharedArrayBuffer, args: Record<string, any>) => {
     console.log(args.dom);
-    let arr = new Int8Array(buffer);
+    const arr = new Int8Array(buffer);
     arr[0] += 1;
-    //@ts-ignore
+    //@ts-ignore was module function
     self.greet();
-    //@ts-ignore
-    let val = self.getValue();
+    //@ts-ignore wasm module function
+    const val = self.getValue();
     console.log(val);
     return arr.buffer;
   };
 }
 
-Deno.test("WASM Worker Should have wasm methods loaded from module", async () => {
+Deno.test("WASM Worker Should have wasm methods loaded from GoLang module", async () => {
   const example: GoTestExample = new GoTestExample(
     "./examples/wasm/tiny-go/primes-2.wasm",
   );
@@ -68,7 +81,7 @@ Deno.test("WASM Worker Should have wasm methods loaded from module", async () =>
       },
       moduleLoader: (path: string) => {
         const fd = Deno.openSync(path);
-        let mod = Deno.readAllSync(fd);
+        const mod = Deno.readAllSync(fd);
         fd.close();
         return mod;
       },

--- a/tests/wasm_instance_wrapper_standup_test.ts
+++ b/tests/wasm_instance_wrapper_standup_test.ts
@@ -12,14 +12,14 @@ class TestExample extends WasmWorkerDefinition {
     super(modulePath);
   }
 
-  public test2(buffer: SharedArrayBuffer, module: Record<string, any>) {
+  test2 = (buffer: SharedArrayBuffer, module: Record<string, any>) => {
     let arr = new Int8Array(buffer);
     arr[0] += 1;
 
     //@ts-ignore method injection from wasm.
     self.primeGenerator();
     return arr.buffer;
-  }
+  };
 }
 
 Deno.test("Wasm Worker Wrapper manager should have config correctly defnined", () => {

--- a/tests/wasm_instance_wrapper_standup_test.ts
+++ b/tests/wasm_instance_wrapper_standup_test.ts
@@ -12,7 +12,7 @@ class TestExample extends WasmWorkerDefinition {
     super(modulePath);
   }
 
-  test2 = (buffer: SharedArrayBuffer, module: Record<string, any>) => {
+  test2 = (buffer: SharedArrayBuffer, _module: Record<string, any>) => {
     let arr = new Int8Array(buffer);
     arr[0] += 1;
 
@@ -42,7 +42,7 @@ Deno.test("Wasm Worker Wrapper manager should have config correctly defnined", (
       },
       moduleLoader: (path: string) => {
         const fd = Deno.openSync(path);
-        let mod = Deno.readAllSync(fd);
+        const mod = Deno.readAllSync(fd);
         fd.close();
         return mod;
       },
@@ -76,7 +76,7 @@ Deno.test("Wasm class members should be defined", () => {
       },
       moduleLoader: (path: string) => {
         const fd = Deno.openSync(path);
-        let mod = Deno.readAllSync(fd);
+        const mod = Deno.readAllSync(fd);
         fd.close();
         return mod;
       },

--- a/tests/wasm_instance_wrapper_static_generation_test.ts
+++ b/tests/wasm_instance_wrapper_static_generation_test.ts
@@ -24,6 +24,20 @@ class RustTestExample extends WasmWorkerDefinition {
     console.log(val);
     return arr.buffer;
   };
+
+  asyncTest = async (
+    buffer: SharedArrayBuffer,
+    _args: Record<string, any>,
+  ): Promise<SharedArrayBuffer> => {
+    const prms: Promise<void> = new Promise((res, _rej) => {
+      const a = 2 + 2;
+      console.log("a value is a", a);
+      res();
+    });
+    await prms;
+
+    return buffer;
+  };
 }
 
 Deno.test("WASM Worker Should generate worker and load functions into global", async () => {
@@ -67,6 +81,8 @@ Deno.test("WASM Worker Should generate worker and load functions into global", a
     assertExists(self["test2"]);
     //@ts-ignore
     await self["test2"]({ dom: "hey" });
+    //@ts-ignore
+    await self["asyncTest"]();
   });
 
   //@ts-ignore

--- a/tests/wasm_instance_wrapper_static_generation_test.ts
+++ b/tests/wasm_instance_wrapper_static_generation_test.ts
@@ -13,7 +13,7 @@ class RustTestExample extends WasmWorkerDefinition {
     super(modulePath);
   }
 
-  public test2(buffer: SharedArrayBuffer, args: Record<string, any>) {
+  test2 = (buffer: SharedArrayBuffer, args: Record<string, any>) => {
     console.log(args.dom);
     let arr = new Int8Array(buffer);
     arr[0] += 1;
@@ -23,7 +23,7 @@ class RustTestExample extends WasmWorkerDefinition {
     let val = self.getValue();
     console.log(val);
     return arr.buffer;
-  }
+  };
 }
 
 Deno.test("WASM Worker Should generate worker and load functions into global", async () => {


### PR DESCRIPTION
Adds support for async method definitions within wrapped classes. Now requires all methods to be declared using arrow syntax. This will be fixed in a follow up with better serialization logic.