### PR TITLE
Fix/code gen namespacing

### DIFF
--- a/src/InstanceWrapper.ts
+++ b/src/InstanceWrapper.ts
@@ -190,12 +190,14 @@ export class InstanceWrapper<T extends WorkerDefinition> {
       Object.getPrototypeOf(this._instance),
     ) as [keyof T];
     const baseKeys = Object.keys(this._instance) as [keyof T];
-
+    console.log("base keys", baseKeys, "instance prototype keys", protoKeys);
+    const allKeys = baseKeys.concat(protoKeys).filter((key) => {
+      return key !== "constructor" && key !== "execMap" && key !== "worker" &&
+        key !== "ModulePath" && key !== "workerString";
+    });
     const wrps: WorkerWrapper[] = [];
-    for (const key of protoKeys.concat(baseKeys)) {
-      key !== "constructor" && key !== "execMap" && key !== "worker" &&
-        key !== "ModulePath" && key !== "workerString" &&
-        wrps.push(new WorkerWrapper(this._instance[key] as WorkerMethod));
+    for (const key of allKeys) {
+      wrps.push(new WorkerWrapper(this._instance[key] as WorkerMethod));
     }
 
     this._wm = new WorkerManager(wrps, this._config.namespace ?? "");

--- a/src/WorkerBridge.ts
+++ b/src/WorkerBridge.ts
@@ -11,7 +11,6 @@ export interface BridgeConfiguration {
 export class WorkerBridge<T> {
   private _workers;
   private _namespace;
-  private _modulePath;
 
   constructor(config: BridgeConfiguration) {
     this._workers = config.workers;
@@ -108,7 +107,7 @@ let prmsRes;
 let moduleWait = new Promise((res, rej) => {
   prmsRes = res;
 });
-console.log("loading worker");
+
 const blob = new Blob([new TextDecoder().decode(new Uint8Array(workerStr))],{ type: "application/typescript" });
 const objUrl = URL.createObjectURL(blob);            
 worker = new Worker(objUrl, {type: "module"});
@@ -188,8 +187,18 @@ worker.onmessage = function(e) {
 
     root += "}";
     root += `
-for (const key of Object.keys(${this._namespace})) {
-  self[key] = ${this._namespace}[key];
+for (const key of Object.keys(${this._namespace ?? "span"})) {
+  self["${this._namespace ?? "span"}"] =  self["${
+      this._namespace ?? "span"
+    }"] != undefined ? self["${this._namespace ?? "span"}"] : {};
+  self["${this._namespace ?? "span"}." + key] = ${
+      this._namespace ?? "span"
+    }[key];
+  console.log("bootstrapping methods to global namespace:", self["${
+      this._namespace ?? "span"
+    }." + key]);
+  self[key] = ${this._namespace ?? "span"}[key];
+  
 }
 self['worker'] = worker;
 `;

--- a/tests/instance_wrapper_runtime_test.ts
+++ b/tests/instance_wrapper_runtime_test.ts
@@ -35,6 +35,7 @@ class TestExample extends WorkerDefinition {
     const prms: Promise<void> = new Promise((res, _rej) => {
       const a = 2 + 2;
       console.log("a value is ", a);
+      console.log("deno api", Deno);
       res();
     });
     await prms;

--- a/tests/instance_wrapper_static_generation_test.ts
+++ b/tests/instance_wrapper_static_generation_test.ts
@@ -56,10 +56,10 @@ Deno.test("Generated bridge should load functions into global", async () => {
   const __dirname = path.dirname(path.fromFileUrl(import.meta.url));
   await import(__dirname + "/../public/js/bridge.js");
 
-  assertExists(self["bar"]);
+  assertExists(self["test.foo"]);
 
-  assertExists(self["bar"]);
+  assertExists(self["test.bar"]);
   await self["foo"]({ hey: "wow" });
-
+  await self["test.foo"]({ foo: "bar" });
   self["worker"].terminate();
 });

--- a/tests/wasm_instance_wrapper_static_generation_test.ts
+++ b/tests/wasm_instance_wrapper_static_generation_test.ts
@@ -81,6 +81,8 @@ Deno.test("WASM Worker Should generate worker and load functions into global", a
     await self["test2"]({ dom: "hey" });
     //@ts-ignore
     await self["asyncTest"]();
+    //@ts-ignore
+    await self["wasmTest.asyncTest"]();
   });
 
   //@ts-ignore


### PR DESCRIPTION
Adds namespacing to methods which are loaded into the `global object` with the `namespace` given in the configuration.
If a namespace is not provided `span` is used as the default.
In a later version flat function hoisting will be removed in favor of explicit name spacing.