### PR TITLE
Ref/add timeouts

### DIFF
--- a/benchmark/wasm_instance_start_bench.ts
+++ b/benchmark/wasm_instance_start_bench.ts
@@ -1,6 +1,8 @@
 //@ts-nocheck
 
 import { InstanceWrapper, WorkerDefinition } from "../src/mod.ts";
+import { existsSync } from "https://deno.land/std/fs/mod.ts";
+import * as path from "https://deno.land/std@0.188.0/path/mod.ts";
 
 class TestExample extends WorkerDefinition {
   public constructor(modulePath: string) {
@@ -79,4 +81,127 @@ Deno.bench("Wasm Worker Start Rust Module loading", async (_b) => {
   await wrapper.start().then(() => {
     example.terminateWorker();
   });
+});
+
+Deno.bench("Wasm Worker Start Code Gen Bootstrapping Rust", async (_b) => {
+  if (!existsSync("./public")) {
+    Deno.mkdirSync("./public");
+  }
+
+  if (!existsSync("./public/bench")) {
+    Deno.mkdirSync("./public/bench");
+  }
+
+  const example: WorkerDefinition = new TestExample();
+
+  const wrapper: InstanceWrapper<TestExample> = new InstanceWrapper<
+    Example
+  >(
+    example,
+    {
+      outputPath: "./public/bench",
+      namespace: "asd",
+      addons: [
+        "./lib/wasm_test.js",
+      ],
+      modulePath: "./examples/wasm/rust/wasm_test_bg.wasm",
+      addonLoader: (path: string) => {
+        return Deno.readTextFileSync(path);
+      },
+      moduleLoader: (path: string) => {
+        const fd = Deno.openSync(path);
+        const mod = Deno.readAllSync(fd);
+        fd.close();
+        return mod;
+      },
+    },
+  );
+  wrapper.create({
+    writeFileSync: Deno.writeFileSync,
+  });
+  const __dirname = path.dirname(path.fromFileUrl(import.meta.url));
+  await import(__dirname + "/../public/bench/bridge.js");
+  self['worker'].terminate();
+});
+
+Deno.bench("Wasm Worker Start Code Gen Bootstrapping Tiny Go", async (_b) => {
+  if (!existsSync("./public")) {
+    Deno.mkdirSync("./public");
+  }
+
+  if (!existsSync("./public/bench")) {
+    Deno.mkdirSync("./public/bench");
+  }
+
+  const example: WorkerDefinition = new TestExample();
+
+  const wrapper: InstanceWrapper<TestExample> = new InstanceWrapper<
+    Example
+  >(
+    example,
+    {
+      outputPath: "./public/bench",
+      namespace: "asd",
+      addons: [
+        "./lib/wasm_exec_tiny.js",
+      ],
+      modulePath: "./examples/wasm/tiny-go/primes-2.wasm",
+      addonLoader: (path: string) => {
+        return Deno.readTextFileSync(path);
+      },
+      moduleLoader: (path: string) => {
+        const fd = Deno.openSync(path);
+        const mod = Deno.readAllSync(fd);
+        fd.close();
+        return mod;
+      },
+    },
+  );
+  wrapper.create({
+    writeFileSync: Deno.writeFileSync,
+  });
+  const __dirname = path.dirname(path.fromFileUrl(import.meta.url));
+  await import(__dirname + "/../public/bench/bridge.js");
+  self['worker'].terminate();
+});
+
+Deno.bench("Wasm Worker Start Code Gen Bootstrapping Go", async (_b) => {
+  if (!existsSync("./public")) {
+    Deno.mkdirSync("./public");
+  }
+
+  if (!existsSync("./public/bench")) {
+    Deno.mkdirSync("./public/bench");
+  }
+
+  const example: WorkerDefinition = new TestExample();
+
+  const wrapper: InstanceWrapper<TestExample> = new InstanceWrapper<
+    Example
+  >(
+    example,
+    {
+      outputPath: "./public/bench",
+      namespace: "asd",
+      addons: [
+        "./lib/wasm_exec.js",
+      ],
+      modulePath: "./examples/wasm/tiny-go/primes-2.wasm",
+      addonLoader: (path: string) => {
+        return Deno.readTextFileSync(path);
+      },
+      moduleLoader: (path: string) => {
+        const fd = Deno.openSync(path);
+        const mod = Deno.readAllSync(fd);
+        fd.close();
+        return mod;
+      },
+    },
+  );
+  wrapper.create({
+    writeFileSync: Deno.writeFileSync,
+  });
+  const __dirname = path.dirname(path.fromFileUrl(import.meta.url));
+  await import(__dirname + "/../public/bench/bridge.js");
+  self['worker'].terminate();
 });

--- a/benchmark/wasm_instance_start_bench.ts
+++ b/benchmark/wasm_instance_start_bench.ts
@@ -121,7 +121,7 @@ Deno.bench("Wasm Worker Start Code Gen Bootstrapping Rust", async (_b) => {
   });
   const __dirname = path.dirname(path.fromFileUrl(import.meta.url));
   await import(__dirname + "/../public/bench/bridge.js");
-  self['worker'].terminate();
+  self["worker"].terminate();
 });
 
 Deno.bench("Wasm Worker Start Code Gen Bootstrapping Tiny Go", async (_b) => {
@@ -162,7 +162,7 @@ Deno.bench("Wasm Worker Start Code Gen Bootstrapping Tiny Go", async (_b) => {
   });
   const __dirname = path.dirname(path.fromFileUrl(import.meta.url));
   await import(__dirname + "/../public/bench/bridge.js");
-  self['worker'].terminate();
+  self["worker"].terminate();
 });
 
 Deno.bench("Wasm Worker Start Code Gen Bootstrapping Go", async (_b) => {
@@ -203,5 +203,5 @@ Deno.bench("Wasm Worker Start Code Gen Bootstrapping Go", async (_b) => {
   });
   const __dirname = path.dirname(path.fromFileUrl(import.meta.url));
   await import(__dirname + "/../public/bench/bridge.js");
-  self['worker'].terminate();
+  self["worker"].terminate();
 });

--- a/examples/js/example.ts
+++ b/examples/js/example.ts
@@ -124,5 +124,4 @@ try {
   console.error("handling the await with a try catch ", e);
 }
 
-console.log(workerPrms.settledCount);
-//example.terminateWorker();
+example.terminateWorker();

--- a/examples/wasm/rust/example.ts
+++ b/examples/wasm/rust/example.ts
@@ -10,9 +10,12 @@ class Example extends WorkerDefinition {
 
   test2 = (buffer: SharedArrayBuffer, _args: Record<string, any>) => {
     let arr = new Int8Array(buffer);
-    arr[0] += 1;
     //@ts-ignore
-    self.greet();
+    let val = self.getValue();
+    arr[0] = val;
+
+    //@ts-ignore
+    self.create_doc();
     return arr.buffer;
   };
 }

--- a/src/InstanceWrapper.ts
+++ b/src/InstanceWrapper.ts
@@ -1,3 +1,4 @@
+import { WorkerPromise } from "./types.ts";
 import {
   DiskIOProvider,
   InstanceConfiguration,
@@ -35,8 +36,14 @@ import { WorkerMethod, WorkerWrapper } from "./WorkerWrapper.ts";
 export class WorkerDefinition {
   public execMap: Record<
     string,
-    (args: Record<string, any>) => Promise<SharedArrayBuffer>
+    (args: Record<string, any>) => WorkerPromise
   > = {};
+
+  /** */
+  public _executionMap: Record<string, any> = {};
+
+  /** */
+  public bufferMap: Record<string, SharedArrayBuffer> = {};
 
   /**
    * worker instance, can be stopped by calling terminateWorker
@@ -45,6 +52,20 @@ export class WorkerDefinition {
   public worker: any | undefined = undefined;
 
   constructor() {}
+
+  /**
+   * @returns
+   */
+  public uuidv4() {
+    //@ts-ignore
+    return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(
+      /[018]/g,
+      (c: number) =>
+        (crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(
+          16,
+        ),
+    );
+  }
 
   /**
    * Run implemented methods from within the worker instance
@@ -57,8 +78,17 @@ export class WorkerDefinition {
   public execute(
     name: keyof this,
     args: Record<string, any> = {},
-  ): Promise<SharedArrayBuffer> {
+  ): WorkerPromise {
     return this.execMap[name as unknown as string](args);
+  }
+
+  /**
+   * Return the promise controlling a specific method within the worker
+   */
+  public get(
+    name: keyof this,
+  ): void | Promise<SharedArrayBuffer> {
+    return this.execMap[name as unknown as string] as any;
   }
 
   /**
@@ -108,7 +138,7 @@ export class InstanceWrapper<T extends WorkerDefinition> {
   private _config: InstanceConfiguration;
   private _instance: WorkerInstance<T>;
   private _wm: WorkerManager | undefined;
-  private _wb: WorkerBridge<T> | undefined;
+  private _wb: WorkerBridge | undefined;
   private _workerString = "";
 
   constructor(instance: WorkerInstance<T>, config: InstanceConfiguration) {
@@ -122,10 +152,13 @@ export class InstanceWrapper<T extends WorkerDefinition> {
    * Current only supports the `onmessage` handler. but object may be accesed as the `worker` property
    */
   public async start(): Promise<void> {
-    this?._wb?.bufferMap(this._instance);
-    const ww = this?._wb?.workerWrappers(this._instance) ?? [];
+    this?._wb?.bufferMap(this._instance as WorkerDefinition);
+    const ww = this?._wb?.workerWrappers(this._instance as WorkerDefinition);
+    if (!ww) {
+      throw new Error("unable to process worker definition");
+    }
     for (const w of ww) {
-      (this._instance as WorkerDefinition).execMap[(w as any)._name] = w;
+      (this._instance as WorkerDefinition).execMap[w._name] = w;
     }
 
     this._workerString = this._workerString + "\n" +
@@ -190,9 +223,10 @@ export class InstanceWrapper<T extends WorkerDefinition> {
       Object.getPrototypeOf(this._instance),
     ) as [keyof T];
     const baseKeys = Object.keys(this._instance) as [keyof T];
-    console.log("base keys", baseKeys, "instance prototype keys", protoKeys);
     const allKeys = baseKeys.concat(protoKeys).filter((key) => {
-      return key !== "constructor" && key !== "execMap" && key !== "worker" &&
+      return key !== "constructor" && key !== "execMap" &&
+        key !== "bufferMap" &&
+        key !== "_executionMap" && key !== "worker" &&
         key !== "ModulePath" && key !== "workerString";
     });
     const wrps: WorkerWrapper[] = [];

--- a/src/InstanceWrapper.ts
+++ b/src/InstanceWrapper.ts
@@ -76,7 +76,7 @@ export class WorkerDefinition {
    * @returns {SharedArrayBuffer}
    */
   public execute(
-    name: keyof this,
+    name: Exclude<keyof this, keyof WorkerDefinition>,
     args: Record<string, any> = {},
   ): WorkerPromise {
     return this.execMap[name as unknown as string](args);

--- a/src/PromiseExtension.ts
+++ b/src/PromiseExtension.ts
@@ -1,0 +1,48 @@
+import { WorkerWrapper } from "./WorkerWrapper.ts";
+import { WorkerDefinition } from "./mod.ts";
+import { WorkerPromise, WorkerPromiseGeneratorNamed } from "./types.ts";
+
+export function buildPromiseExtension(
+  id: string,
+  wrapper: WorkerWrapper,
+  generator: WorkerPromiseGeneratorNamed,
+  self: WorkerDefinition,
+): WorkerPromise {
+  let promiseResolve, promiseReject;
+  //@ts-ignore building object
+  const prms: WorkerPromise = new Promise<SharedArrayBuffer>(
+    (resolve, reject) => {
+      promiseResolve = resolve;
+      promiseReject = reject;
+    },
+  ).finally(() => {
+    for (let i = 0; i < prms.timerIds.length; i++) {
+      clearTimeout(prms.timerIds[i]);
+    }
+    prms.settledCount += 1;
+  });
+
+  prms.resolve = promiseResolve as any;
+  prms.reject = promiseReject as any;
+  prms.timerIds = [];
+  prms.settledCount = 0;
+  prms.name = name;
+  prms.wrapper = generator;
+  prms.timeout = (delay: number) => {
+    const timerId = setTimeout(() => {
+      self.worker.postMessage({
+        name: `${wrapper.WorkerName}`,
+        id: id,
+        action: "TERM",
+      });
+
+      prms.reject(
+        new Error("Timeout has occured, aborting worker execution"),
+      );
+    }, delay);
+
+    prms.timerIds.push(timerId);
+  };
+
+  return prms;
+}

--- a/src/WorkerManager.ts
+++ b/src/WorkerManager.ts
@@ -51,7 +51,19 @@ self.setInterval(async () => {
     }.workerState,
                 res: retVal
               });
-              
+              delete tasks[task.id];
+            }).catch((err) => {
+              reject();
+              postMessage({
+                name: task.name,
+                buffer: task.buffer,
+                id: task.id,
+                error: err.toString(),
+                state: ${
+      this._namespace != "" ? this._namespace : "span"
+    }.workerState,
+              });
+              delete tasks[task.id];
             });
           } else {
             postMessage({
@@ -65,15 +77,16 @@ self.setInterval(async () => {
           });
           }
         } catch(e) {
-          console.error('Error while executing task. Error trace:' + e.message);
           postMessage({
             name: task.name,
             buffer: task.buffer,
             id: task.id,
+            error: e.toString(),
             state: ${
       this._namespace != "" ? this._namespace : "span"
     }.workerState
-          });                  
+          });
+          delete tasks[task.id];                
         }
       });
 

--- a/src/WorkerManager.ts
+++ b/src/WorkerManager.ts
@@ -19,36 +19,81 @@ export class WorkerManager {
   }
 
   public CreateOnMessageHandler(): string {
-    return `const execData = [];
-            self.setInterval(async () => {
-            if (execData.length > 0 && ${
+    return `
+const execData = [];
+const tasks = {};
+self.setInterval(async () => {
+  if (execData.length > 0 && ${
       this._namespace != "" ? this._namespace : "span"
     }.workerState === "READY") {
-                try {
-                  const task = execData.shift();
-                  let res = _execMap[task.name](task.buffer, task.args);
-                  if (res.then) {
-                    res = await res;
-                  }
-
-                  postMessage({
-                      name: task.name,
-                      buffer: task.buffer,
-                      id: task.id,
-                      state: ${
+    const task = execData.shift();
+    if (task.action === 'TERM') {
+      tasks[task.id].reject();
+      delete tasks[task.id];
+    } else {
+      let res, rej;
+      tasks[task.id] = new Promise<void>((resolve, reject) => {
+        res = resolve;
+        rej = reject;
+        try {
+          let res = _execMap[task.name](task.buffer, task.args);
+          if (res.then) {
+            let retVal;
+            res.then((val) => {
+              retVal = val;
+              resolve();
+              postMessage({
+                name: task.name,
+                buffer: task.buffer,
+                id: task.id,
+                state: ${
       this._namespace != "" ? this._namespace : "span"
     }.workerState,
-                      res
-                  });
-                } catch(e) {
-                  console.error('Error while executing task. Error trace:' + e.message);
-                }
-            }
-          }, 1);
+                res: retVal
+              });
+              
+            });
+          } else {
+            postMessage({
+              name: task.name,
+              buffer: task.buffer,
+              id: task.id,
+              state: ${
+      this._namespace != "" ? this._namespace : "span"
+    }.workerState,
+              res
+          });
+          }
+        } catch(e) {
+          console.error('Error while executing task. Error trace:' + e.message);
+          postMessage({
+            name: task.name,
+            buffer: task.buffer,
+            id: task.id,
+            state: ${
+      this._namespace != "" ? this._namespace : "span"
+    }.workerState
+          });                  
+        }
+      });
 
-          self.onmessage = (e) => {
-            execData.push(e.data);
-          };
+      tasks[task.id].resolve = res;
+      tasks[task.id].reject = rej;
+      tasks[task.id].catch((err) => {
+        err && postMessage({
+          name: task.name,
+          buffer: task.buffer,
+          id: task.id,
+          state: ${this._namespace != "" ? this._namespace : "span"}.workerState
+        });           
+      });
+    }
+  }
+}, 1);
+
+self.onmessage = (e) => {
+  execData.push(e.data);
+};
 `;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,22 @@ export type WorkerInstance<T extends WorkerDefinition> = WorkerFunctions<
 >;
 
 export declare type WorkerMethod = SyncWorkerMethod | AsyncWorkerMethod;
+export declare type WorkerPromise = Promise<SharedArrayBuffer> & {
+  resolve: (value: SharedArrayBuffer | PromiseLike<SharedArrayBuffer>) => void;
+  reject: (reason: any) => void;
+  timeout: (delay: number) => void;
+  wrapper: WorkerPromiseGeneratorNamed;
+
+  timerIds: number[];
+  settledCount: number;
+  name: string;
+};
+export declare type WorkerPromiseGenerator = (
+  args: Record<string, any>,
+) => WorkerPromise;
+export declare type WorkerPromiseGeneratorNamed =
+  & { _name: string }
+  & WorkerPromiseGenerator;
 
 export declare type AsyncWorkerMethod = (
   buffer: SharedArrayBuffer,

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,7 +50,7 @@ type KeepCallable<V, R = V, N = never> = V extends (...args: any) => any ? R
   : N;
 
 type BaseFunctionTypes<T> = (
-  name: keyof T,
+  name: Exclude<keyof T, keyof WorkerDefinition>,
   args?: Record<string, any>,
 ) => Promise<SharedArrayBuffer> | void;
 

--- a/tests/instance_wrapper_runtime_test.ts
+++ b/tests/instance_wrapper_runtime_test.ts
@@ -72,7 +72,9 @@ Deno.test("Worker Wrapper manager should respect buffer when returned", async ()
 
       //@ts-ignore need to add types
       workerPrms.timeout(1_000);
-      return workerPrms;
+      return workerPrms.finally(() => {
+        assertEquals(workerPrms.settledCount, 1);
+      });
     },
     Error,
     "Timeout has occured, aborting worker execution",

--- a/tests/instance_wrapper_static_generation_test.ts
+++ b/tests/instance_wrapper_static_generation_test.ts
@@ -60,6 +60,13 @@ Deno.test("Generated bridge should load functions into global", async () => {
 
   assertExists(self["test.bar"]);
   await self["foo"]({ hey: "wow" });
-  await self["test.foo"]({ foo: "bar" });
+  const prms = self["test.foo"]({ foo: "bar" });
+  await prms;
+
+  assertExists(prms.timeout);
+  assertExists(prms.resolve);
+  assertExists(prms.reject);
+  assertExists(prms.timerIds);
+
   self["worker"].terminate();
 });


### PR DESCRIPTION
- Adds support for timeouts of execution across the worker boundary
- Adds handling of errors which occur in the remote execution context, which now will cause the promise to reject with the error wrapped.

TODO: Create custom error instance types