### PR TITLE
Feat/pooling

### DIFF
--- a/benchmark/wasm_instance_start_bench.ts
+++ b/benchmark/wasm_instance_start_bench.ts
@@ -21,7 +21,9 @@ class TestExample extends WorkerDefinition {
   };
 }
 
-Deno.bench("Wasm Worker Start Go Module loading", async (_b) => {
+Deno.bench("Wasm Worker Start Go Module loading", {
+  group: "non imported initalization",
+}, async (_b) => {
   const example: WorkerDefinition = new TestExample();
 
   const wrapper: InstanceWrapper<TestExample> = new InstanceWrapper<
@@ -52,7 +54,9 @@ Deno.bench("Wasm Worker Start Go Module loading", async (_b) => {
   });
 });
 
-Deno.bench("Wasm Worker Start Rust Module loading", async (_b) => {
+Deno.bench("Wasm Worker Start Rust Module loading", {
+  group: "non imported initalization",
+}, async (_b) => {
   const example: WorkerDefinition = new TestExample();
 
   const wrapper: InstanceWrapper<TestExample> = new InstanceWrapper<
@@ -83,7 +87,9 @@ Deno.bench("Wasm Worker Start Rust Module loading", async (_b) => {
   });
 });
 
-Deno.bench("Wasm Worker Start Code Gen Bootstrapping Rust", async (_b) => {
+Deno.bench("Wasm Worker Start Code Gen Bootstrapping Rust", {
+  group: "imported initalization",
+}, async (_b) => {
   if (!existsSync("./public")) {
     Deno.mkdirSync("./public");
   }
@@ -121,10 +127,12 @@ Deno.bench("Wasm Worker Start Code Gen Bootstrapping Rust", async (_b) => {
   });
   const __dirname = path.dirname(path.fromFileUrl(import.meta.url));
   await import(__dirname + "/../public/bench/bridge.js");
-  self["worker"].terminate();
+  self["pool"].terminate();
 });
 
-Deno.bench("Wasm Worker Start Code Gen Bootstrapping Tiny Go", async (_b) => {
+Deno.bench("Wasm Worker Start Code Gen Bootstrapping Tiny Go", {
+  group: "imported initalization",
+}, async (_b) => {
   if (!existsSync("./public")) {
     Deno.mkdirSync("./public");
   }
@@ -162,10 +170,12 @@ Deno.bench("Wasm Worker Start Code Gen Bootstrapping Tiny Go", async (_b) => {
   });
   const __dirname = path.dirname(path.fromFileUrl(import.meta.url));
   await import(__dirname + "/../public/bench/bridge.js");
-  self["worker"].terminate();
+  self["pool"].terminate();
 });
 
-Deno.bench("Wasm Worker Start Code Gen Bootstrapping Go", async (_b) => {
+Deno.bench("Wasm Worker Start Code Gen Bootstrapping Go", {
+  group: "imported initalization",
+}, async (_b) => {
   if (!existsSync("./public")) {
     Deno.mkdirSync("./public");
   }
@@ -203,5 +213,5 @@ Deno.bench("Wasm Worker Start Code Gen Bootstrapping Go", async (_b) => {
   });
   const __dirname = path.dirname(path.fromFileUrl(import.meta.url));
   await import(__dirname + "/../public/bench/bridge.js");
-  self["worker"].terminate();
+  self["pool"].terminate();
 });

--- a/examples/js/example.ts
+++ b/examples/js/example.ts
@@ -48,7 +48,7 @@ class Example extends WorkerDefinition {
       ["encrypt", "decrypt"],
     );
 
-    console.log("generated key", keyPair);
+    console.log("generated key", _args);
     return buffer;
   };
 
@@ -56,7 +56,7 @@ class Example extends WorkerDefinition {
     buffer: SharedArrayBuffer,
     _args: Record<string, any>,
   ): Promise<SharedArrayBuffer> => {
-    const adapter = await navigator.gpu.requestAdapter();
+    const adapter = {};
     console.log("gpu adapter", adapter);
 
     return buffer;
@@ -85,14 +85,13 @@ const wrapper: InstanceWrapper<Example> = new InstanceWrapper<Example>(
   {} as InstanceConfiguration,
 );
 
-wrapper.start();
+await wrapper.start();
 
-await example.execute("addOne", { name: "foo" }).then(
-  (buf: SharedArrayBuffer) => {
-    assertExists(buf);
-  },
-);
-await example.execute("getKeyPair");
+await example.execute("addOne", { name: "foo" });
+
+for (let i = 0; i < 48; i++) {
+  example.execute("getKeyPair", { num: i });
+}
 
 await example.execute("fib", { count: 46 });
 await example.execute("getGpuAdapter");
@@ -114,4 +113,7 @@ try {
   assertIsError(e);
 }
 
-example.terminateWorker();
+setInterval(() => {
+  console.log(example.pool?.getThreadStates());
+}, 500);
+//example.terminateWorker();

--- a/src/Pool.ts
+++ b/src/Pool.ts
@@ -1,0 +1,117 @@
+import { resolve } from "https://deno.land/std@0.211.0/path/resolve.ts";
+import { WorkerPromise } from "./types.ts";
+import { WorkerHandler } from "./Worker.ts";
+
+export class Pool {
+  public threads: WorkerHandler[] = [];
+  public tasks: any = [];
+  private _args: any = [];
+  private _waitLock: Promise<void> | undefined;
+  private _waitLockResolver: any | undefined;
+
+  constructor(args: any) {
+    this._args = args;
+  }
+
+  init = async (definition: string): Promise<void> => {
+    for (let i = 0; i < this._args.workerCount; i++) {
+      //@ts-ignore deno option
+      this.threads.push(new WorkerHandler(definition, {}));
+    }
+    const isReady = () => {
+      const ready = this.threads.filter((thrad) => thrad.isReady()).length ===
+        this._args.workerCount;
+      return ready;
+    };
+    while (!isReady()) {
+      await this._wait(10);
+    }
+  };
+
+  findWorkerForId = (id: string): WorkerHandler | undefined => {
+    for (let i = 0; i < this.threads.length; i++) {
+      if (this.threads[i]._executionMap[id]) {
+        return this.threads[i];
+      }
+    }
+
+    return undefined;
+  };
+
+  exec = (task: WorkerPromise) => {
+    const thread = this.threads.find((t) => {
+      return t.isReady();
+    });
+    if (!thread) {
+      task.reject(new Error("Max pool queue reached"));
+    }
+
+    this.tasks.push(task);
+    this._next().catch(() => {});
+  };
+
+  getThreadStates = (): Record<string, any>[] => {
+    return this.threads.map((t) => {
+      return {
+        state: t.state,
+        tasks: Object.keys(t._executionMap),
+      };
+    });
+  };
+
+  terminate = (): void => {
+    for (let i = 0; i < this.threads.length; i++) {
+      this.threads[i].worker.terminate();
+    }
+  };
+
+  _next = (): Promise<void> => {
+    return new Promise<void>((resolve, _reject) => {
+      if (this.tasks.length > 0) {
+        const thread = this.threads.find((t) => {
+          return t.isReady();
+        });
+        if (!thread) {
+          _reject();
+          return;
+        }
+        const task = this.tasks.shift();
+        thread._executionMap[task.id] = {
+          promise: task,
+          resolve: task.resolve,
+          reject: task.reject,
+        };
+        thread.worker.postMessage({
+          name: task.name,
+          id: task.id,
+          buffer: task.buffer,
+          args: task.args,
+        });
+
+        thread.state = "BUSY";
+
+        this._next().catch(() => {});
+      } else {
+        resolve();
+      }
+    });
+  };
+
+  _wait = (ms: number): Promise<void> => {
+    return new Promise<void>((res, _) => {
+      setTimeout(res, ms);
+    });
+  };
+
+  /** */
+  public static uuidv4(): string {
+    //@ts-ignore
+    return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(
+      /[018]/g,
+      (c: number) =>
+        (crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(
+          16,
+        ),
+    );
+  }
+}

--- a/src/Worker.ts
+++ b/src/Worker.ts
@@ -1,0 +1,56 @@
+export class WorkerHandler {
+  private sourceDef: string;
+  private _args: any;
+
+  public _executionMap: Record<string, any> = {};
+  public worker: any;
+  public state: string = "BUSY";
+
+  constructor(source: string, args: any) {
+    this._args = args;
+    this.sourceDef = source;
+
+    const blob = new Blob(
+      [source],
+      { type: "application/typescript" },
+    );
+
+    this.worker = new Worker(URL.createObjectURL(blob), {
+      //@ts-ignore: deno flag
+      deno: true,
+      type: "module",
+    });
+
+    this.worker.onmessage = (e: MessageEvent<any>) => {
+      if (e.data.ready) {
+        this.state = "IDLE";
+        return;
+      }
+
+      if (!this._executionMap[e.data.id]) {
+        return;
+      }
+      const context = this._executionMap[e.data.id];
+
+      if (e.data.error) {
+        context.promise &&
+          context.reject(new Error("Error occured in worker: ", e.data.error));
+      } else {
+        context.promise && context.resolve(e.data.buffer);
+        this._executionMap[e.data.id].buffer = e.data.buffer;
+      }
+
+      delete this._executionMap[e.data.id];
+
+      if (Object.keys(this._executionMap).length === 0) {
+        this.state = "IDLE";
+      } else {
+        this.state = "BUSY";
+      }
+    };
+  }
+
+  public isReady(): boolean {
+    return this.state === "IDLE" || Object.keys(this._executionMap).length < 10;
+  }
+}

--- a/src/WorkerManager.ts
+++ b/src/WorkerManager.ts
@@ -35,7 +35,7 @@ self.setInterval(async () => {
       ${
       this._namespace != "" ? this._namespace : "span"
     }.tasks[task.id].reject();
-      delete tasks[task.id];
+      delete ${this._namespace != "" ? this._namespace : "span"}.tasks[task.id];
     } else {
       let res, rej;
       ${

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { WorkerDefinition } from "./InstanceWrapper.ts";
+import { Pool } from "./Pool.ts";
 import { WorkerWrapper } from "./WorkerWrapper.ts";
 
 export interface BridgeConfiguration {
@@ -74,11 +75,14 @@ export declare type WorkerPromise = Promise<SharedArrayBuffer> & {
   resolve: (value: SharedArrayBuffer | PromiseLike<SharedArrayBuffer>) => void;
   reject: (reason: any) => void;
   timeout: (delay: number) => void;
+  pool: Pool;
   wrapper: WorkerPromiseGeneratorNamed;
-
+  buffer: SharedArrayBuffer;
+  args: any;
   timerIds: number[];
   settledCount: number;
   name: string;
+  id: string;
 };
 export declare type WorkerPromiseGenerator = (
   args: Record<string, any>,

--- a/tests/instance_wrapper_static_generation_test.ts
+++ b/tests/instance_wrapper_static_generation_test.ts
@@ -101,5 +101,5 @@ Deno.test("Generated bridge should load functions into global", async () => {
     "Timeout has occured, aborting worker execution",
   );
 
-  self["worker"].terminate();
+  self["pool"].terminate();
 });

--- a/tests/pool_test.ts
+++ b/tests/pool_test.ts
@@ -17,4 +17,6 @@ Deno.test("Pool should initalize with correct worker count", async () => {
 
   const states = pool.getThreadStates();
   assertEquals(states.length, poolSize);
+  
+  pool.terminate();
 });

--- a/tests/pool_test.ts
+++ b/tests/pool_test.ts
@@ -1,0 +1,20 @@
+import {
+  assertEquals,
+  assertExists,
+} from "https://deno.land/std@0.210.0/assert/mod.ts";
+
+import { Pool } from "../src/Pool.ts";
+
+Deno.test("Pool should initalize with correct worker count", async () => {
+  const poolSize = 10;
+  const pool = new Pool({ workerCount: poolSize });
+  await pool.init("console.log('hello world from pool test');");
+  assertEquals(pool.threads.length, poolSize);
+
+  for (let i = 0; i < pool.threads.length; i++) {
+    assertEquals(pool.threads[i].isReady(), true);
+  }
+
+  const states = pool.getThreadStates();
+  assertEquals(states.length, poolSize);
+});

--- a/tests/wasm_instance_wrapper_static_generation_test.ts
+++ b/tests/wasm_instance_wrapper_static_generation_test.ts
@@ -13,7 +13,6 @@ class RustTestExample extends WorkerDefinition {
   }
 
   test2 = (buffer: SharedArrayBuffer, args: Record<string, any>) => {
-    console.log(args.dom);
     let arr = new Int8Array(buffer);
     arr[0] += 1;
     //@ts-ignore
@@ -73,7 +72,7 @@ Deno.test("WASM Worker Should generate worker and load functions into global", a
   });
 
   const __dirname = path.dirname(path.fromFileUrl(import.meta.url));
-  await import(__dirname + "/../public/wasm/bridge.js").then(async (module) => {
+  await import(__dirname + "/../public/wasm/bridge.js").then(async () => {
     //@ts-ignore
     assertExists(self["test2"]);
     //@ts-ignore
@@ -85,5 +84,5 @@ Deno.test("WASM Worker Should generate worker and load functions into global", a
   });
 
   //@ts-ignore
-  self["worker"].terminate();
+  self["pool"].terminate();
 });


### PR DESCRIPTION
- Adds support for a `pool` which allows a configurable number of `workers` to be created and pulled from for executing methods.
- Allows for a configurable task tolerance per worker which will buffer workers with tasks from the `pool`

- Replaces `worker` with `pool` in `WorkerDefinition`