### PR TITLE
fix: worker standup

### DIFF
--- a/src/InstanceWrapper.ts
+++ b/src/InstanceWrapper.ts
@@ -1,4 +1,4 @@
-import { WorkerAny } from "./mod.ts";
+import type { WorkerAny } from "./mod.ts";
 import type { Pool } from "./Pool.ts";
 import type { TaskPromise } from "./PromiseExtension.ts";
 
@@ -120,7 +120,7 @@ export class WorkerDefinition {
  *  // log the result
  *  console.log(new Uint8Array(buffer)[0]);
  */
-export class InstanceWrapper<T extends WorkerDefinition> {
+export class InstanceWrapper<T extends WorkerDefinition | CallableFunction> {
   private _config: InstanceConfiguration;
   private _instance: T;
   private _wm: WorkerManager | undefined;
@@ -155,12 +155,12 @@ export class InstanceWrapper<T extends WorkerDefinition> {
     // this will allow the promise being awaited to resolve by the caller.
     this._workerString += this._config.modulePath
       ? ""
-      : `postMessage({ready: true}); ${
+      : `postMessage({READY: true}); ${
         this._config.namespace != undefined ? this._config.namespace : "span"
       }.workerState = "READY";`;
 
     await this?._wb?.workerBootstrap(
-      this._instance as T,
+      this._instance as WorkerDefinition,
       this._workerString,
       {
         workerCount: this._config.workerCount ?? 1,
@@ -178,7 +178,7 @@ export class InstanceWrapper<T extends WorkerDefinition> {
     }
 
     await this?._wb?.workerBootstrap(
-      this._instance as T,
+      this._instance as WorkerDefinition,
       this._workerString,
     );
   }
@@ -292,7 +292,7 @@ ${this._config.namespace ?? "span"}.workerState = "PENDING";
           initSync && initSync(uint8);
           for (const key of Object.keys(wasm)){
             self[key] = wasm[key];
-          } 
+          }
           ${this._config.namespace ?? "span"}.workerState = "READY";
           postMessage({
             ready: true

--- a/src/InstanceWrapper.ts
+++ b/src/InstanceWrapper.ts
@@ -233,7 +233,7 @@ export class InstanceWrapper<T extends WorkerDefinition | CallableFunction> {
 
     let execFd = `
 let ${this._config.namespace ?? "span"} = {}
-${this._config.namespace ?? "span"}.workerState = "PENDING";
+${this._config.namespace ?? "span"}.workerState = "BUSY";
 `;
 
     for (const addon of this._config?.addons ?? []) {
@@ -245,7 +245,7 @@ ${this._config.namespace ?? "span"}.workerState = "PENDING";
     this._workerString += execFd;
     this._config.modulePath
       ? this._workerString += this._genWebAssemblyBinding()
-      : this._workerString += `postMessage({ready: true}); ${
+      : this._workerString += `postMessage({READY: true}); ${
         this._config.namespace ?? "span"
       }.workerState = "READY";`;
   }
@@ -284,7 +284,7 @@ ${this._config.namespace ?? "span"}.workerState = "PENDING";
           }
           ${this._config.namespace ?? "span"}.workerState = "READY";
           postMessage({
-            ready: true
+            READY: true
           })
         });
       } else {
@@ -295,7 +295,7 @@ ${this._config.namespace ?? "span"}.workerState = "PENDING";
           }
           ${this._config.namespace ?? "span"}.workerState = "READY";
           postMessage({
-            ready: true
+            READY: true
           });
         } else if(typeof wasm_bindgen !== "undefined") {
           wasm_bindgen && ((module) =>{
@@ -307,7 +307,7 @@ ${this._config.namespace ?? "span"}.workerState = "PENDING";
 
             ${this._config.namespace ?? "span"}.workerState = "READY";
             postMessage({
-              ready: true
+              READY: true
             });
           })(wasm_bindgen);
         }

--- a/src/Pool.ts
+++ b/src/Pool.ts
@@ -33,7 +33,7 @@ export class Pool {
         this._args.workerCount;
     let totalWaitTime = 0;
     while (!ready) {
-      if (totalWaitTime >= 10_000) {
+      if (totalWaitTime >= 2_000) {
         this.terminate();
         throw new Error("could not stand up all workers shutting down");
       }

--- a/src/Pool.ts
+++ b/src/Pool.ts
@@ -21,17 +21,18 @@ export class Pool {
 
     for (let i = 0; i < this._args.workerCount; i++) {
       this.threads.push(
-        new WorkerHandler(definition, { taskCount: this._args.taskCount }),
+        new WorkerHandler(definition, {
+          taskCount: this._args.taskCount,
+        }),
       );
     }
 
-    let ready = this.threads.filter((thread) => thread.isReady()).length ===
+    let ready = this.threads.filter((thread) => thread.state === "IDLE").length ===
       this._args.workerCount;
     while (!ready) {
       await this._wait(10);
-      ready = this.threads.filter((thread) =>
-        thread.isReady()
-      ).length === this._args.workerCount;
+      ready = this.threads.filter((thread) => thread.state === "IDLE").length ===
+        this._args.workerCount;
     }
   };
 
@@ -109,7 +110,7 @@ export class Pool {
         return;
       }
 
-      thread._executionMap[task.id] = task,
+      (thread._executionMap[task.id] = task),
         thread.worker.postMessage({
           name: task.name,
           id: task.id,
@@ -148,9 +149,10 @@ export class Pool {
     return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(
       /[018]/g,
       (c: number) =>
-        (crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(
-          16,
-        ),
+        (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))
+          .toString(
+            16,
+          ),
     );
   }
 }

--- a/src/Pool.ts
+++ b/src/Pool.ts
@@ -33,7 +33,7 @@ export class Pool {
         this._args.workerCount;
     let totalWaitTime = 0;
     while (!ready) {
-      if (totalWaitTime >= 1_000) {
+      if (totalWaitTime >= 10_000) {
         this.terminate();
         throw new Error("could not stand up all workers shutting down");
       }

--- a/tests/instance_wrapper_runtime_test.ts
+++ b/tests/instance_wrapper_runtime_test.ts
@@ -59,7 +59,7 @@ class TestExample extends WorkerDefinition {
 
 Deno.test("Worker Wrapper manager should respect buffer when returned", async () => {
   const inst = new TestExample();
-  const wrapper = new InstanceWrapper<TestExample>(inst, { workerCount: 5 });
+  const wrapper = new InstanceWrapper<TestExample>(inst, { workerCount: 2 });
 
   await wrapper.start();
 
@@ -92,7 +92,7 @@ Deno.test("Worker Wrapper manager should respect buffer when returned", async ()
 
 Deno.test("Worker Wrapper manager should respect argument value in buffer when returned", async () => {
   const inst = new TestExample();
-  const wrapper = new InstanceWrapper<TestExample>(inst, { workerCount: 5 });
+  const wrapper = new InstanceWrapper<TestExample>(inst, { workerCount: 2 });
 
   await wrapper.start();
   await inst.execute("bar", { value: 10 }).promise.then((buf) => {
@@ -104,7 +104,7 @@ Deno.test("Worker Wrapper manager should respect argument value in buffer when r
 
 Deno.test("Worker Wrapper Generated Promise should handle rejections", async () => {
   const inst = new TestExample();
-  const wrapper = new InstanceWrapper<TestExample>(inst, { workerCount: 5 });
+  const wrapper = new InstanceWrapper<TestExample>(inst, { workerCount: 2 });
 
   await wrapper.start();
   await inst.execute("testErrorCatch", {}).promise.catch((err) => {
@@ -116,7 +116,7 @@ Deno.test("Worker Wrapper Generated Promise should handle rejections", async () 
 Deno.test("Pooling should correctly route requests to workers with buffer allowance", async () => {
   const inst = new TestExample();
   const wrapper = new InstanceWrapper<TestExample>(inst, {
-    workerCount: 5,
+    workerCount: 2,
     taskCount: 2,
   });
 
@@ -147,7 +147,7 @@ Deno.test("Pooling should correctly route requests to workers with buffer allowa
 Deno.test("Timeout should kill worker if there is no response", async () => {
   const inst = new TestExample();
   const wrapper = new InstanceWrapper<TestExample>(inst, {
-    workerCount: 5,
+    workerCount: 2,
     taskCount: 2,
   });
 

--- a/tests/instance_wrapper_runtime_test.ts
+++ b/tests/instance_wrapper_runtime_test.ts
@@ -4,6 +4,7 @@ import {
   assertRejects,
 } from "https://deno.land/std@0.210.0/assert/mod.ts";
 import { InstanceWrapper, ThreadState, WorkerDefinition } from "../src/mod.ts";
+import { TaskPromise } from "../src/PromiseExtension.ts";
 
 class TestExample extends WorkerDefinition {
   public constructor() {
@@ -114,25 +115,25 @@ Deno.test("Worker Wrapper Generated Promise should handle rejections", async () 
 });
 
 Deno.test("Pooling should correctly route requests to workers with buffer allowance", async () => {
+  const workerCount = 2;
+  const taskCount = 2;
   const inst = new TestExample();
   const wrapper = new InstanceWrapper<TestExample>(inst, {
-    workerCount: 2,
-    taskCount: 2,
+    workerCount: workerCount,
+    taskCount: taskCount,
   });
 
   await wrapper.start();
-  const promises = [];
-  for (let i = 0; i < 6; i++) {
+  const promises: TaskPromise[] = [];
+  for (let i = 0; i < workerCount + 1; i++) {
     promises.push(inst.execute("testAsync", {}));
   }
 
-  assertEquals(promises.length, 6);
-
   for (let i = 0; i < inst.pool?.getThreadStates().length!; i++) {
-    if (i <= Math.ceil(5 / 2) - 1) {
+    if (i === 0) {
       assertEquals(inst.pool?.getThreadStates()[i].tasks.length, 2);
     } else {
-      assertEquals(inst.pool?.getThreadStates()[i].tasks.length, 0);
+      assertEquals(inst.pool?.getThreadStates()[i].tasks.length, 1);
     }
   }
 
@@ -161,7 +162,7 @@ Deno.test("Timeout should kill worker if there is no response", async () => {
     // catch the timeout error
   }
 
-  assertEquals(inst.pool!.threads.length, 4);
+  assertEquals(inst.pool!.threads.length, 1);
   inst.terminateWorker();
 });
 

--- a/tests/instance_wrapper_standup_test.ts
+++ b/tests/instance_wrapper_standup_test.ts
@@ -21,8 +21,8 @@ class TestExample extends WorkerDefinition {
 
 Deno.test("Worker Wrapper should be defined", () => {
   const inst = new TestExample();
-  const wrapper = new InstanceWrapper<TestExample>(inst, { workerCount: 5 });
-  assertEquals(wrapper["_config"], { workerCount: 5 });
+  const wrapper = new InstanceWrapper<TestExample>(inst, { workerCount: 2 });
+  assertEquals(wrapper["_config"], { workerCount: 2 });
   assertEquals(inst, wrapper["_instance"]);
 });
 

--- a/tests/instance_wrapper_standup_test.ts
+++ b/tests/instance_wrapper_standup_test.ts
@@ -26,29 +26,29 @@ Deno.test("Worker Wrapper should be defined", () => {
   assertEquals(inst, wrapper["_instance"]);
 });
 
-Deno.test("Worker Wrapper manager should be defined when started", () => {
+Deno.test("Worker Wrapper manager should be defined when started", async () => {
   const inst = new TestExample();
   const wrapper = new InstanceWrapper<TestExample>(inst, { workerCount: 1 });
-  wrapper.start();
+  await wrapper.start();
   inst.terminateWorker();
   assertExists(wrapper["_wm"]);
   assertExists(wrapper["_wb"]);
 });
 
-Deno.test("Worker Wrapper manager should create correct number of workers", () => {
+Deno.test("Worker Wrapper manager should create correct number of workers", async () => {
   const inst = new TestExample();
   const wrapper = new InstanceWrapper<TestExample>(inst, { workerCount: 1 });
-  wrapper.start();
+  await wrapper.start();
   inst.terminateWorker();
   //@ts-ignore is defined
   assertEquals(wrapper["_wm"]["_workers"].length, 1);
 });
 
-Deno.test("Worker Wrapper manager should default to 1 worker if not configured", () => {
+Deno.test("Worker Wrapper manager should default to 1 worker if not configured", async () => {
   const inst = new TestExample();
   //@ts-ignore remove workerCount for test case
   const wrapper = new InstanceWrapper<TestExample>(inst, {});
-  wrapper.start();
+  await wrapper.start();
   inst.terminateWorker();
   //@ts-ignore is defined
   assertEquals(wrapper["_wm"]["_workers"].length, 1);

--- a/tests/instance_wrapper_static_generation_test.ts
+++ b/tests/instance_wrapper_static_generation_test.ts
@@ -71,7 +71,7 @@ Deno.test("Generated bridge should load functions into global", async () => {
     const wrapper = new InstanceWrapper<TestExample>(inst, {
       outputPath: path.join(Deno.cwd(), "public", "js"),
       namespace: "test",
-      workerCount: 5,
+      workerCount: 2,
     });
 
     if (!existsSync(path.join(Deno.cwd(), "public"))) {

--- a/tests/pool_test.ts
+++ b/tests/pool_test.ts
@@ -5,7 +5,9 @@ import { Pool } from "../src/Pool.ts";
 Deno.test("Pool should initalize with correct worker count", async () => {
   const poolSize = 10;
   const pool = new Pool({ workerCount: poolSize, taskCount: 10 });
-  await pool.init("console.log('hello world from pool test');");
+  await pool.init(
+    "console.log('hello world from pool test'); postMessage({READY: true})",
+  );
   assertEquals(pool.threads.length, poolSize);
 
   for (let i = 0; i < pool.threads.length; i++) {
@@ -21,7 +23,9 @@ Deno.test("Pool should initalize with correct worker count", async () => {
 Deno.test("Pool.removeWorker should remove correct worker and terminate", async () => {
   const poolSize = 10;
   const pool = new Pool({ workerCount: poolSize, taskCount: 10 });
-  await pool.init("console.log('hello world from pool test');");
+  await pool.init(
+    "console.log('hello world from pool test'); postMessage({READY: true})",
+  );
   const workerId = pool.threads[0].id;
   pool.removeWorker(workerId);
   assertEquals(pool.threads.length, poolSize - 1);

--- a/tests/promise_extension_tests.ts
+++ b/tests/promise_extension_tests.ts
@@ -56,7 +56,7 @@ Deno.test("Promise should reject and throw error on timeout", async () => {
 Deno.test("Promise should resolve and return array buffer", async () => {
   const inst = new TestExample();
   const wrapper = new InstanceWrapper<TestExample>(inst, {
-    workerCount: 5,
+    workerCount: 2,
     taskCount: 2,
   });
   await wrapper.start();
@@ -71,7 +71,7 @@ Deno.test("Promise should resolve and return array buffer", async () => {
 Deno.test("Promise should reject and throw error on timeout when infinite loop occures", async () => {
   const inst = new TestExample();
   const wrapper = new InstanceWrapper<TestExample>(inst, {
-    workerCount: 5,
+    workerCount: 2,
     taskCount: 2,
   });
   await wrapper.start();

--- a/tests/wasm_instance_wrapper_runtime_test.ts
+++ b/tests/wasm_instance_wrapper_runtime_test.ts
@@ -96,7 +96,7 @@ Deno.test("WASM Worker Should have wasm methods loaded from GoLang module", asyn
         fd.close();
         return mod;
       },
-      workerCount: 5,
+      workerCount: 2,
     },
   );
 
@@ -150,7 +150,7 @@ Deno.test("WASM Worker method should correct pass arguments", async () => {
         fd.close();
         return mod;
       },
-      workerCount: 5,
+      workerCount: 2,
     },
   );
 
@@ -194,7 +194,7 @@ Deno.test("WASM Worker Should have wasm methods loaded from Rust compiled module
         fd.close();
         return source;
       },
-      workerCount: 5,
+      workerCount: 2,
     },
   );
 

--- a/tests/wasm_instance_wrapper_standup_test.ts
+++ b/tests/wasm_instance_wrapper_standup_test.ts
@@ -112,7 +112,7 @@ Deno.test("Wasm class should have correct worker number on start", async () => {
         fd.close();
         return mod;
       },
-      workerCount: 5,
+      workerCount: 2,
     },
   );
 
@@ -146,7 +146,7 @@ Deno.test("Wasm class ", async () => {
         fd.close();
         return mod;
       },
-      workerCount: 5,
+      workerCount: 2,
     },
   );
 

--- a/tests/wasm_instance_wrapper_standup_test.ts
+++ b/tests/wasm_instance_wrapper_standup_test.ts
@@ -89,7 +89,7 @@ Deno.test("Wasm class members should be defined", () => {
   assertExists(wrapper["_wm"]);
 });
 
-Deno.test("Wasm class should have correct worker number on start", () => {
+Deno.test("Wasm class should have correct worker number on start", async () => {
   const example: TestExample = new TestExample();
   const wasmLibPath = path.join(Deno.cwd(), "lib", "wasm_exec_tiny.js");
 
@@ -116,14 +116,14 @@ Deno.test("Wasm class should have correct worker number on start", () => {
     },
   );
 
-  wrapper.start();
+  await wrapper.start();
   example.terminateWorker();
 
   //@ts-ignore private members defined
   assertEquals(wrapper["_wm"]["_workers"].length, 1);
 });
 
-Deno.test("Wasm class ", () => {
+Deno.test("Wasm class ", async () => {
   const example: TestExample = new TestExample();
   const wasmLibPath = path.join(Deno.cwd(), "lib", "wasm_exec_tiny.js");
 
@@ -150,7 +150,7 @@ Deno.test("Wasm class ", () => {
     },
   );
 
-  wrapper.start();
+  await wrapper.start();
   example.terminateWorker();
 
   //@ts-ignore private members defined

--- a/tests/wasm_instance_wrapper_standup_test.ts
+++ b/tests/wasm_instance_wrapper_standup_test.ts
@@ -45,7 +45,7 @@ Deno.test("Wasm Worker Wrapper manager should have config correctly defnined", (
         fd.close();
         return mod;
       },
-      workerCount: 5,
+      workerCount: 2,
     },
   );
 
@@ -79,7 +79,7 @@ Deno.test("Wasm class members should be defined", () => {
         fd.close();
         return mod;
       },
-      workerCount: 5,
+      workerCount: 2,
     },
   );
 

--- a/tests/wasm_instance_wrapper_static_generation_test.ts
+++ b/tests/wasm_instance_wrapper_static_generation_test.ts
@@ -74,7 +74,7 @@ Deno.test("WASM Worker Should generate worker and load functions into global", a
           fd.close();
           return source;
         },
-        workerCount: 5,
+        workerCount: 2,
       },
     );
 


### PR DESCRIPTION
Fixes an issue where starting the pool would not wait on the worker stand up operations to conclude. Resulting in worker state transitions not occurring from `BUSY` to `IDLE`